### PR TITLE
Informative names

### DIFF
--- a/graphkit/base.py
+++ b/graphkit/base.py
@@ -133,6 +133,16 @@ class Operation(object):
             self.__setattr__(k, state[k])
         self._after_init()
 
+    def __repr__(self):
+        """
+        Display more informative names for the Operation class
+        """
+        return u"%s(name='%s', needs=%s, provides=%s)" % \
+            (self.__class__.__name__,
+             self.name,
+             self.needs,
+             self.provides)
+
 
 class NetworkOperation(Operation):
     def __init__(self, **kwargs):

--- a/graphkit/functional.py
+++ b/graphkit/functional.py
@@ -128,6 +128,19 @@ class operation(Operation):
 
         return FunctionalOperation(**total_kwargs)
 
+    def __repr__(self):
+        """
+        Display more informative names for the Operation class
+        """
+        return u"%s(name='%s', needs=%s, provides=%s, fn=%s)" % \
+            (self.__class__.__name__,
+             self.name,
+             self.needs,
+             self.provides,
+             self.fn.__name__)
+
+
+
 
 class compose(object):
     """


### PR DESCRIPTION
@tobibaum 

Minor change to enable more informative names when errors occurs or when printing out pipeline.net.steps  e.g. you'll see outputs like this in python rather than just a plain `FunctionalOperation` string:

```
[FunctionalOperation(name="c", needs=['ao', 'bo'], provides=['co'], fn=fn2),
 FunctionalOperation(name="e", needs=['ao', 'bo'], provides=['eo'], fn=fn2)]
```