### PR TITLE
We introduce a cache to avoid computing find_necessary_steps during each inference call

### DIFF
--- a/test/test_graphkit.py
+++ b/test/test_graphkit.py
@@ -300,7 +300,7 @@ def test_multi_threading():
     pipeline = compose(name="pipeline", merge=True)(
         operation(name="op_a", needs=['a', 'b'], provides='c')(op_a),
         operation(name="op_b", needs=['c', 'b'], provides='d')(op_b),
-        operation(name="op_c", needs=['a', 'b'], provides='e')(op_b),
+        operation(name="op_c", needs=['a', 'b'], provides='e')(op_c),
     )
 
     def infer(i):

--- a/test/test_graphkit.py
+++ b/test/test_graphkit.py
@@ -280,6 +280,43 @@ def test_parallel_execution():
     # make sure results are the same using either method
     assert result_sequential == result_threaded
 
+def test_multi_threading():
+    import time
+    import random
+    from multiprocessing.dummy import Pool
+
+    def op_a(a, b):
+        time.sleep(random.random()*.02)
+        return a+b
+
+    def op_b(c, b):
+        time.sleep(random.random()*.02)
+        return c+b
+
+    def op_c(a, b):
+        time.sleep(random.random()*.02)
+        return a*b
+
+    pipeline = compose(name="pipeline", merge=True)(
+        operation(name="op_a", needs=['a', 'b'], provides='c')(op_a),
+        operation(name="op_b", needs=['c', 'b'], provides='d')(op_b),
+        operation(name="op_c", needs=['a', 'b'], provides='e')(op_b),
+    )
+
+    def infer(i):
+        # data = open("616039-bradpitt.jpg").read()
+        outputs = ["c", "d", "e"]
+        results = pipeline({"a": 1, "b":2}, outputs)
+        assert tuple(sorted(results.keys())) == tuple(sorted(outputs)), (outputs, results)
+        return results
+
+    N = 100
+    for i in range(20, 200):
+        pool = Pool(i)
+        pool.map(infer, range(N))
+        pool.close()
+
+
 ####################################
 # Backwards compatibility
 ####################################


### PR DESCRIPTION
@tobibaum 

I've introduced a cache to avoid computing find_necessary_steps multiple times during each inference call. This has 2 benefits: 1) it reduces computation time of the compute call 2) it avoids a subtle multi-threading bug in networkx when accessing the graph from a high number of threads.

The following test should fail without these changes:

https://github.com/yahoo/graphkit/compare/multithreading_fix?expand=1#diff-eb68f4dabe94fb4dfdc148f0ef8961f8R283

Thanks for reviewing!

