### PR TITLE
Fix versioning

### DIFF
--- a/graphkit/__init__.py
+++ b/graphkit/__init__.py
@@ -2,6 +2,7 @@
 # Licensed under the terms of the Apache License, Version 2.0. See the LICENSE file associated with the project for terms.
 
 __author__ = 'hnguyen'
+__version__ = '1.2.2'
 
 from .functional import operation, compose
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 # Copyright 2016, Yahoo Inc.
 # Licensed under the terms of the Apache License, Version 2.0. See the LICENSE file associated with the project for terms.
-
+import os
+import re
 import io
 from setuptools import setup
 
@@ -15,8 +16,6 @@ and many other domains.
 
 # Grab the version using convention described by flask
 # https://github.com/pallets/flask/blob/master/setup.py#L10
-import os
-import re
 with io.open('graphkit/__init__.py', 'rt', encoding='utf8') as f:
     version = re.search(r'__version__ = \'(.*?)\'', f.read()).group(1)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 # Copyright 2016, Yahoo Inc.
 # Licensed under the terms of the Apache License, Version 2.0. See the LICENSE file associated with the project for terms.
 
-import os
+import io
 from setuptools import setup
 
 LONG_DESCRIPTION = """
@@ -13,15 +13,16 @@ those operations.  Such graphs are useful in computer vision, machine learning,
 and many other domains.
 """
 
-# Grab the version as the tag name from the Travis build, or else use a default.
-if os.path.isfile('VERSION'):
-     VERSION = open('VERSION').read()
-else:
-     VERSION = os.environ.get('TRAVIS_TAG', '1.1')
+# Grab the version using convention described by flask
+# https://github.com/pallets/flask/blob/master/setup.py#L10
+import os
+import re
+with io.open('graphkit/__init__.py', 'rt', encoding='utf8') as f:
+    version = re.search(r'__version__ = \'(.*?)\'', f.read()).group(1)
 
 setup(
      name='graphkit',
-     version=VERSION,
+     version=version,
      description='Lightweight computation graphs for Python',
      long_description=LONG_DESCRIPTION,
      author='Huy Nguyen, Arel Cordero, Pierre Garrigues, Rob Hess, Tobi Baumgartner, Clayton Mellina',


### PR DESCRIPTION
@tobibaum, this PR restructures how we obtain the version for this package. I am running into a bug where we upload one version to pypi that is controlled using TRAVIS_TAG, but when you pip install that same package, the version reverts to `1.1` . This is because the pip installed version is controlled by a manually specified default. 

Since we have to manually specify the version anyway, let's cut out the the other automated behavior that is causing a mismatch in the versions. 