### PR TITLE
FIX(build): py2 needs pinning networkx-2.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,10 @@ setup(
      author_email='huyng@yahoo-inc.com',
      url='http://github.com/yahoo/graphkit',
      packages=['graphkit'],
-     install_requires=['networkx'],
+     install_requires=[
+          "networkx; python_version >= '3.5'",
+          "networkx == 2.2; python_version < '3.5'",
+     ],
      extras_require={
           'plot': ['pydot', 'matplotlib']
      },


### PR DESCRIPTION
`networkx` dependency was pinned on Python-2.x because travis builds on PY2 were failing because of this err:
```Running networkx-2.3/setup.py -q bdist_egg --dist-dir /tmp/easy_install-dKD38C/networkx-2.3/egg-dist-tmp-MBvy5O
312NetworkX 2.3+ requires Python 3.5 or later (2.7 detected).
313             
314For Python 2.7, please install version 2.2 using:
315
316$ pip install 'networkx==2.2'
```

---
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
