### PR TITLE
ENH: ignore unsatified operations with partial inputs

### DIFF
--- a/graphkit/functional.py
+++ b/graphkit/functional.py
@@ -204,7 +204,10 @@ class compose(object):
         provides = order_preserving_uniquifier(chain(*[op.provides for op in operations]))
         needs = order_preserving_uniquifier(chain(*[op.needs for op in operations]),
                                             set(provides))  # unordered, not iterated
-
+        # Mark them all as optional, now that #18 calmly ignores
+        # non-fully satisfied operations.
+        needs = [optional(n) for op in operations for n in op.needs]
+        
         # compile network
         net = Network()
         for op in operations:

--- a/graphkit/functional.py
+++ b/graphkit/functional.py
@@ -3,6 +3,8 @@
 
 from itertools import chain
 
+from boltons.setutils import IndexedSet as iset
+
 from .base import Operation, NetworkOperation
 from .network import Network
 from .modifiers import optional
@@ -28,7 +30,7 @@ class FunctionalOperation(Operation):
 
         result = zip(self.provides, result)
         if outputs:
-            outputs = set(outputs)
+            outputs = sorted(set(outputs))
             result = filter(lambda x: x[0] in outputs, result)
 
         return dict(result)
@@ -185,22 +187,23 @@ class compose(object):
 
         # If merge is desired, deduplicate operations before building network
         if self.merge:
-            merge_set = set()
+            merge_set = iset()  # Preseve given node order.
             for op in operations:
                 if isinstance(op, NetworkOperation):
                     net_ops = filter(lambda x: isinstance(x, Operation), op.net.steps)
                     merge_set.update(net_ops)
                 else:
                     merge_set.add(op)
-            operations = list(merge_set)
+            operations = merge_set
 
         def order_preserving_uniquifier(seq, seen=None):
-            seen = seen if seen else set()
+            seen = seen if seen else set()  # unordered, not iterated
             seen_add = seen.add
             return [x for x in seq if not (x in seen or seen_add(x))]
 
         provides = order_preserving_uniquifier(chain(*[op.provides for op in operations]))
-        needs = order_preserving_uniquifier(chain(*[op.needs for op in operations]), set(provides))
+        needs = order_preserving_uniquifier(chain(*[op.needs for op in operations]),
+                                            set(provides))  # unordered, not iterated
 
         # compile network
         net = Network()

--- a/graphkit/network.py
+++ b/graphkit/network.py
@@ -8,6 +8,7 @@ import networkx as nx
 from io import StringIO
 
 from .base import Operation
+from .modifiers import optional
 
 
 class DataPlaceholderNode(str):
@@ -141,6 +142,65 @@ class Network(object):
                 raise TypeError("Unrecognized network graph node")
 
 
+    def _collect_satisfiable_needs(self, operation, inputs, satisfiables, visited):
+        """
+        Recusrively check if operation inputs are given/calculated (satisfied), or not.
+
+        :param satisfiables:
+            the set to populate with satisfiable operations
+
+        :param visited:
+            a cache of operations & needs, not to visit them again
+        :return:
+            true if opearation is satisfiable
+        """
+        assert isinstance(operation, Operation), (
+            "Expected Operation, got:",
+            type(operation),
+        )
+
+        if operation in visited:
+            return visited[operation]
+
+
+        def is_need_satisfiable(need):
+            if need in visited:
+                return visited[need]
+
+            if need in inputs:
+                satisfied = True
+            else:
+                need_providers = list(self.graph.predecessors(need))
+                satisfied = bool(need_providers) and any(
+                    self._collect_satisfiable_needs(op, inputs, satisfiables, visited)
+                    for op in need_providers
+                )
+            visited[need] = satisfied
+
+            return satisfied
+
+        satisfied = all(
+            is_need_satisfiable(need)
+            for need in operation.needs
+            if not isinstance(need, optional)
+        )
+        if satisfied:
+            satisfiables.add(operation)
+        visited[operation] = satisfied
+
+        return satisfied
+
+
+    def _collect_satisfiable_operations(self, nodes, inputs):
+        satisfiables = set()
+        visited = {}
+        for node in nodes:
+            if node not in visited and isinstance(node, Operation):
+                self._collect_satisfiable_needs(node, inputs, satisfiables, visited)
+
+        return satisfiables
+
+
     def _find_necessary_steps(self, outputs, inputs):
         """
         Determines what graph steps need to pe run to get to the requested
@@ -204,6 +264,13 @@ class Network(object):
             # Get rid of the unnecessary nodes from the set of necessary ones.
             necessary_nodes -= unnecessary_nodes
 
+        # Drop (un-satifiable) operations with partial inputs.
+        # See https://github.com/yahoo/graphkit/pull/18
+        #
+        satisfiables = self._collect_satisfiable_operations(necessary_nodes, inputs)
+        for node in list(necessary_nodes):
+            if isinstance(node, Operation) and node not in satisfiables:
+                necessary_nodes.remove(node)
 
         necessary_steps = [step for step in self.steps if step in necessary_nodes]
 

--- a/graphkit/network.py
+++ b/graphkit/network.py
@@ -422,8 +422,8 @@ class Network(object):
 
         # save plot
         if filename:
-            basename, ext = os.path.splitext(filename)
-            with open(filename, "w") as fh:
+            _basename, ext = os.path.splitext(filename)
+            with open(filename, "wb") as fh:
                 if ext.lower() == ".png":
                     fh.write(g.create_png())
                 elif ext.lower() == ".dot":

--- a/graphkit/network.py
+++ b/graphkit/network.py
@@ -126,19 +126,16 @@ class Network(object):
                 # Add instructions to delete predecessors as possible.  A
                 # predecessor may be deleted if it is a data placeholder that
                 # is no longer needed by future Operations.
-                for predecessor in self.graph.predecessors(node):
+                for need in self.graph.pred[node]:
                     if self._debug:
-                        print("checking if node %s can be deleted" % predecessor)
-                    predecessor_still_needed = False
+                        print("checking if node %s can be deleted" % need)
                     for future_node in ordered_nodes[i+1:]:
-                        if isinstance(future_node, Operation):
-                            if predecessor in future_node.needs:
-                                predecessor_still_needed = True
-                                break
-                    if not predecessor_still_needed:
+                        if isinstance(future_node, Operation) and need in future_node.needs:
+                            break
+                    else:
                         if self._debug:
-                            print("  adding delete instruction for %s" % predecessor)
-                        self.steps.append(DeleteInstruction(predecessor))
+                            print("  adding delete instruction for %s" % need)
+                        self.steps.append(DeleteInstruction(need))
 
             else:
                 raise TypeError("Unrecognized network graph node")

--- a/graphkit/network.py
+++ b/graphkit/network.py
@@ -107,7 +107,7 @@ class Network(object):
         self.steps = []
 
         # create an execution order such that each layer's needs are provided.
-        ordered_nodes = list(nx.dag.topological_sort(self.graph))
+        ordered_nodes = list(nx.topological_sort(self.graph))
 
         # add Operations evaluation steps, and instructions to free data.
         for i, node in enumerate(ordered_nodes):

--- a/graphkit/network.py
+++ b/graphkit/network.py
@@ -7,6 +7,8 @@ import networkx as nx
 
 from io import StringIO
 
+from boltons.setutils import IndexedSet as iset
+
 from .base import Operation
 
 
@@ -107,7 +109,7 @@ class Network(object):
         self.steps = []
 
         # create an execution order such that each layer's needs are provided.
-        ordered_nodes = list(nx.topological_sort(self.graph))
+        ordered_nodes = iset(nx.topological_sort(self.graph))
 
         # add Operations evaluation steps, and instructions to free data.
         for i, node in enumerate(ordered_nodes):
@@ -163,7 +165,7 @@ class Network(object):
         """
 
         # return steps if it has already been computed before for this set of inputs and outputs
-        outputs = tuple(sorted(outputs)) if isinstance(outputs, (list, set)) else outputs
+        outputs = tuple(sorted(outputs)) if isinstance(outputs, (list, set, iset)) else outputs
         inputs_keys = tuple(sorted(inputs.keys()))
         cache_key = (inputs_keys, outputs)
         if cache_key in self._necessary_steps_cache:
@@ -175,7 +177,7 @@ class Network(object):
             # If caller requested all outputs, the necessary nodes are all
             # nodes that are reachable from one of the inputs.  Ignore input
             # names that aren't in the graph.
-            necessary_nodes = set()
+            necessary_nodes = set()  # unordered, not iterated
             for input_name in iter(inputs):
                 if graph.has_node(input_name):
                     necessary_nodes |= nx.descendants(graph, input_name)
@@ -186,7 +188,7 @@ class Network(object):
             # are made unecessary because we were provided with an input that's
             # deeper into the network graph.  Ignore input names that aren't
             # in the graph.
-            unnecessary_nodes = set()
+            unnecessary_nodes = set()  # unordered, not iterated
             for input_name in iter(inputs):
                 if graph.has_node(input_name):
                     unnecessary_nodes |= nx.ancestors(graph, input_name)
@@ -194,7 +196,7 @@ class Network(object):
             # Find the nodes we need to be able to compute the requested
             # outputs.  Raise an exception if a requested output doesn't
             # exist in the graph.
-            necessary_nodes = set()
+            necessary_nodes = set()  # unordered, not iterated
             for output_name in outputs:
                 if not graph.has_node(output_name):
                     raise ValueError("graphkit graph does not have an output "
@@ -266,7 +268,7 @@ class Network(object):
         necessary_nodes = self._find_necessary_steps(outputs, named_inputs)
 
         # this keeps track of all nodes that have already executed
-        has_executed = set()
+        has_executed = set()  # unordered, not iterated
 
         # with each loop iteration, we determine a set of operations that can be
         # scheduled, then schedule them onto a thread pool, then collect their
@@ -464,6 +466,7 @@ def ready_to_schedule_operation(op, has_executed, graph):
         A boolean indicating whether the operation may be scheduled for
         execution based on what has already been executed.
     """
+    # unordered, not iterated
     dependencies = set(filter(lambda v: isinstance(v, Operation),
                               nx.ancestors(graph, op)))
     return dependencies.issubset(has_executed)

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,10 @@ setup(
      author_email='huyng@yahoo-inc.com',
      url='http://github.com/yahoo/graphkit',
      packages=['graphkit'],
-     install_requires=['networkx'],
+     install_requires=[
+          "networkx; python_version >= '3.5'",
+          "networkx == 2.2; python_version < '3.5'",
+     ],
      extras_require={
           'plot': ['pydot', 'matplotlib']
      },

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
      install_requires=[
           "networkx; python_version >= '3.5'",
           "networkx == 2.2; python_version < '3.5'",
+          "boltons"  # for IndexSet
      ],
      extras_require={
           'plot': ['pydot', 'matplotlib']


### PR DESCRIPTION
## Reason:
The purpose is not to require a "perfect" input model for the dag to run,
but the algorithm to find the minimum viable subgraph that can compute.

Useful also when 2 (or more) operations provide the same output,
and provided inputs fully satisfy only one of operation.

## Changes
For instance, the graph below with this PR can go ahead and compute 
- `ab_plus_c=21` when given just `a=10` & `b1=2`, and
- `ab_plus_c=6` when given just `a=10` & `b2=2`:

![t](https://user-images.githubusercontent.com/501585/65835805-455a8000-e2f3-11e9-9944-ab1d8af31ab5.png)

Before this PR, the above graph would fail on *execution time* while trying to evaluate *needlesly* 
the un-satisfied operations.

**NOTE** that it is an invasive change and have repercussions to many decision of this library.

---
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
