### PR TITLE
FIX(#13, plot): PY2 era BUG when writing plot-diagrams; give sample code in the into

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,13 @@ python:
 install:
   - pip install Sphinx sphinx_rtd_theme codecov packaging
   - "python -c $'import os, packaging.version as version\\nv = version.parse(os.environ.get(\"TRAVIS_TAG\", \"1.0\")).public\\nwith open(\"VERSION\", \"w\") as f: f.write(v)'"
-  - python setup.py install
+  - pip install -e .[test]
   - cd docs
   - make clean html
   - cd ..
 
 script:
-  - python setup.py nosetests --with-coverage --cover-package=graphkit
+  - pytest -v --cov=graphkit
 
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: python
 
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
+  - "3.6"
+  - "3.7"
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,16 @@ python:
   - "2.7"
   - "3.4"
   - "3.5"
+addons:
+  apt:
+    packages:
+      - graphviz
+
 
 install:
   - pip install Sphinx sphinx_rtd_theme codecov packaging
   - "python -c $'import os, packaging.version as version\\nv = version.parse(os.environ.get(\"TRAVIS_TAG\", \"1.0\")).public\\nwith open(\"VERSION\", \"w\") as f: f.write(v)'"
-  - python setup.py install
+  - pip install .[plot]
   - cd docs
   - make clean html
   - cd ..

--- a/README.md
+++ b/README.md
@@ -51,6 +51,19 @@ print(out)
 
 As you can see, any function can be used as an operation in GraphKit, even ones imported from system modules!
 
+For debugging, you may plot the workflow with one of these methods:
+
+```python
+   graph.net.plot(show=True)               # open a matplotlib window
+   graph.net.plot("path/to/workflow.png")  # supported files: .png .dot .jpg .jpeg .pdf .svg
+```
+
+> **NOTE**: For plots, `graphviz` must be in your PATH, and `pydot` & `matplotlib` python packages installed.
+> You may install both when installing *graphkit* with its `plot` extras:
+> ```python
+> pip install graphkit[plot]
+> ```
+
 # License
 
 Code licensed under the Apache License, Version 2.0 license. See LICENSE file for terms.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -69,6 +69,18 @@ Here's a Python script with an example GraphKit computation graph that produces 
 
 As you can see, any function can be used as an operation in GraphKit, even ones imported from system modules!
 
+For debugging, you may plot the workflow with one of these methods::
+
+   graph.net.plot(show=True)               # open a matplotlib window
+   graph.net.plot("path/to/workflow.png")  # supported files: .png .dot .jpg .jpeg .pdf .svg
+
+.. NOTE:: 
+  For plots, ``graphviz`` must be in your PATH, and ``pydot` & ``matplotlib`` python packages installed.
+  You may install both when installing *graphkit* with its `plot` extras::
+ 
+      pip install graphkit[plot]
+
+
 License
 -------
 

--- a/graphkit/base.py
+++ b/graphkit/base.py
@@ -197,7 +197,7 @@ class NetworkOperation(Operation):
         :return:
             An instance of the :mod`pydot` graph
 
-        See :func:`network.plot_graph()` for the plot legend and example code.
+        See :func:`graphkit.plot.plot_graph()` for the plot legend and example code.
         """
         return self.net.plot(filename, show, jupyter, inputs, outputs, solution)
 

--- a/graphkit/base.py
+++ b/graphkit/base.py
@@ -177,7 +177,7 @@ class NetworkOperation(Operation):
         :param str filename:
             Write diagram into a file.
             Common extensions are ``.png .dot .jpg .jpeg .pdf .svg``
-            call :func:`network.supported_plot_formats()` for more.
+            call :func:`plot.supported_plot_formats()` for more.
         :param show:
             If it evaluates to true, opens the  diagram in a  matplotlib window.
             If it equals `-1`, it plots but does not open the Window.

--- a/graphkit/base.py
+++ b/graphkit/base.py
@@ -174,9 +174,26 @@ class NetworkOperation(Operation):
     def plot(self, filename=None, show=False,
             inputs=None, outputs=None, solution=None):
         """
-        Plot a *Graphviz* graph and return it, if no other argument provided.
+        :param str filename:
+            Write diagram into a file.
+            The extension must be one of: ``.png .dot .jpg .jpeg .pdf .svg``
+            Prefer ``.pdf`` or ``.svg`` to see solution-values in tooltips.
+        :param boolean show:
+            If it evaluates to true, opens the  diagram in a  matplotlib window.
+        :param inputs:
+            an optional name list, any nodes in there are plotted
+            as a "house"
+        :param outputs:
+            an optional name list, any nodes in there are plotted
+            as an "inverted-house"
+        :param solution:
+            an optional dict with values to annotate nodes
+            (currently content not shown, but node drawn as "filled")
 
-        See :func:`network.plot_graph()` for arguments, legend, and example code.
+        :return:
+            An instance of the :mod`pydot` graph
+
+        See :func:`network.plot_graph()` for the plot legend and example code.
         """
         return self.net.plot(filename, show, inputs, outputs, solution)
 

--- a/graphkit/base.py
+++ b/graphkit/base.py
@@ -173,6 +173,11 @@ class NetworkOperation(Operation):
 
     def plot(self, filename=None, show=False,
             inputs=None, outputs=None, solution=None):
+        """
+        Plot a *Graphviz* graph and return it, if no other argument provided.
+
+        See :func:`network.plot_graph()` for arguments, legend, and example code.
+        """
         return self.net.plot(filename, show, inputs, outputs, solution)
 
     def __getstate__(self):

--- a/graphkit/base.py
+++ b/graphkit/base.py
@@ -176,8 +176,8 @@ class NetworkOperation(Operation):
         """
         :param str filename:
             Write diagram into a file.
-            The extension must be one of: ``.png .dot .jpg .jpeg .pdf .svg``
-            Prefer ``.pdf`` or ``.svg`` to see solution-values in tooltips.
+            Common extensions are ``.png .dot .jpg .jpeg .pdf .svg``
+            call :func:`network.supported_plot_formats()` for more.
         :param boolean show:
             If it evaluates to true, opens the  diagram in a  matplotlib window.
         :param inputs:

--- a/graphkit/base.py
+++ b/graphkit/base.py
@@ -171,15 +171,19 @@ class NetworkOperation(Operation):
         assert method in options
         self._execution_method = method
 
-    def plot(self, filename=None, show=False,
+    def plot(self, filename=None, show=False, jupyter=None,
             inputs=None, outputs=None, solution=None):
         """
         :param str filename:
             Write diagram into a file.
             Common extensions are ``.png .dot .jpg .jpeg .pdf .svg``
             call :func:`network.supported_plot_formats()` for more.
-        :param boolean show:
+        :param show:
             If it evaluates to true, opens the  diagram in a  matplotlib window.
+            If it equals `-1`, it plots but does not open the Window.
+        :param jupyter:
+            If it evaluates to true, return an SVG suitable to render 
+            in *jupyter notebook cells* (`ipython` must be installed).
         :param inputs:
             an optional name list, any nodes in there are plotted
             as a "house"
@@ -195,7 +199,7 @@ class NetworkOperation(Operation):
 
         See :func:`network.plot_graph()` for the plot legend and example code.
         """
-        return self.net.plot(filename, show, inputs, outputs, solution)
+        return self.net.plot(filename, show, jupyter, inputs, outputs, solution)
 
     def __getstate__(self):
         state = Operation.__getstate__(self)

--- a/graphkit/base.py
+++ b/graphkit/base.py
@@ -171,8 +171,9 @@ class NetworkOperation(Operation):
         assert method in options
         self._execution_method = method
 
-    def plot(self, filename=None, show=False):
-        return self.net.plot(filename=filename, show=show)
+    def plot(self, filename=None, show=False,
+            inputs=None, outputs=None, solution=None):
+        return self.net.plot(filename, show, inputs, outputs, solution)
 
     def __getstate__(self):
         state = Operation.__getstate__(self)

--- a/graphkit/base.py
+++ b/graphkit/base.py
@@ -172,7 +172,7 @@ class NetworkOperation(Operation):
         self._execution_method = method
 
     def plot(self, filename=None, show=False):
-        self.net.plot(filename=filename, show=show)
+        return self.net.plot(filename=filename, show=show)
 
     def __getstate__(self):
         state = Operation.__getstate__(self)

--- a/graphkit/network.py
+++ b/graphkit/network.py
@@ -381,7 +381,26 @@ class Network(object):
         """
         Plot a *Graphviz* graph and return it, if no other argument provided.
 
-        See :func:`network.plot_graph()` for arguments, legend, and example code.
+        :param str filename:
+            Write diagram into a file.
+            The extension must be one of: ``.png .dot .jpg .jpeg .pdf .svg``
+            Prefer ``.pdf`` or ``.svg`` to see solution-values in tooltips.
+        :param boolean show:
+            If it evaluates to true, opens the  diagram in a  matplotlib window.
+        :param inputs:
+            an optional name list, any nodes in there are plotted
+            as a "house"
+        :param outputs:
+            an optional name list, any nodes in there are plotted
+            as an "inverted-house"
+        :param solution:
+            an optional dict with values to annotate nodes
+            (currently content not shown, but node drawn as "filled")
+
+        :return:
+            An instance of the :mod`pydot` graph
+
+        See :func:`network.plot_graph` for the plot legend and example code.
         """
         return plot_graph(self.graph, filename, show, self.steps,
                           inputs, outputs, solution)
@@ -476,24 +495,25 @@ def plot_graph(graph, filename=None, show=False, steps=None,
     :param graph:
         what to plot
     :param str filename:
-        Write the output to a file.
+        Write diagram into a file.
         The extension must be one of: ``.png .dot .jpg .jpeg .pdf .svg``
         Prefer ``.pdf`` or ``.svg`` to see solution-values in tooltips.
     :param boolean show:
-        If this is set to True, use matplotlib to show the graph diagram
-        (Default: False)
+        If it evaluates to true, opens the  diagram in a  matplotlib window.
     :param steps:
         a list of nodes & instructions to overlay on the diagram
     :param inputs:
-        an optional list, any nodes in there are plotted as `"house"
-        <https://graphviz.gitlab.io/_pages/doc/info/shapes.html)>`_
+        an optional name list, any nodes in there are plotted
+        as a "house"
     :param outputs:
-        an optional list, any nodes in there are plotted as `"invhouse"
-    :param outputs:
-        an optional dict, any values in there are included in the node-name
+        an optional name list, any nodes in there are plotted
+        as an "inverted-house"
+    :param solution:
+        an optional dict with values to annotate nodes
+        (currently content not shown, but node drawn as "filled")
 
-    :returns:
-        An instance of the pydot graph
+    :return:
+        An instance of the :mod`pydot` graph
 
     **Example:**
 
@@ -530,6 +550,7 @@ def plot_graph(graph, filename=None, show=False, steps=None,
                 kw = {'color': 'red', 'penwidth': 2}
 
             # SHAPE change if in inputs/outputs.
+            # tip: https://graphviz.gitlab.io/_pages/doc/info/shapes.html
             shape="rect"
             if inputs and outputs and nx_node in inputs and nx_node in outputs:
                 shape="hexagon"

--- a/graphkit/network.py
+++ b/graphkit/network.py
@@ -375,6 +375,17 @@ class Network(object):
             return {k: cache[k] for k in iter(cache) if k in outputs}
 
 
+    @staticmethod
+    def supported_plot_writers():
+        return {
+            ".png": lambda gplot: gplot.create_png(),
+            ".dot": lambda gplot: gplot.to_string(),
+            ".jpg": lambda gplot: gplot.create_jpeg(),
+            ".jpeg": lambda gplot: gplot.create_jpeg(),
+            ".pdf": lambda gplot: gplot.create_pdf(),
+            ".svg": lambda gplot: gplot.create_svg(),
+        }
+
     def plot(self, filename=None, show=False):
         """
         Plot the graph.
@@ -422,23 +433,16 @@ class Network(object):
 
         # save plot
         if filename:
-            supported_plot_formaters = {
-                ".png": g.create_png,
-                ".dot": g.to_string,
-                ".jpg": g.create_jpeg,
-                ".jpeg": g.create_jpeg,
-                ".pdf": g.create_pdf,
-                ".svg": g.create_svg,
-            }
             _basename, ext = os.path.splitext(filename)
-            plot_formater = supported_plot_formaters.get(ext.lower())
-            if not plot_formater:
-                raise Exception(
+            writers = Network.supported_plot_writers()
+            plot_writer = Network.supported_plot_writers().get(ext.lower())
+            if not plot_writer:
+                raise ValueError(
                     "Unknown file format for saving graph: %s"
-                    "  File extensions must be one of: .png .dot .jpg .jpeg .pdf .svg"
-                    % ext)
+                    "  File extensions must be one of: %s"
+                    % (ext, ' '.join(writers)))
             with open(filename, "wb") as fh:
-                fh.write(plot_formater())
+                fh.write(plot_writer(g))
 
         # display graph via matplotlib
         if show:

--- a/graphkit/network.py
+++ b/graphkit/network.py
@@ -463,8 +463,9 @@ def plot_graph(graph, filename=None, show=False, steps=None,
 
     ARROWS
 
-    - **solid black arrows**: dependencies (target ``need`` source, 
-      sources ``provide`` target)
+    - **solid black arrows**: dependencies (source-data are``need``\ed
+      by target-operations, sources-operations ``provide`` target-data)
+    - **dashed black arrows**: optional needs
     - **green-dotted arrows**: execution steps labeled in succession
 
     :param graph:
@@ -547,7 +548,12 @@ def plot_graph(graph, filename=None, show=False, steps=None,
     for src, dst in graph.edges():
         src_name = get_node_name(src)
         dst_name = get_node_name(dst)
-        edge = pydot.Edge(src=src_name, dst=dst_name)
+        kw = {}
+        if isinstance(dst, Operation) and any(n == src
+                                              and isinstance(n, optional)
+                                              for n in dst.needs):
+            kw["style"] = "dashed"
+        edge = pydot.Edge(src=src_name, dst=dst_name, **kw)
         g.add_edge(edge)
 
     # draw steps sequence

--- a/graphkit/network.py
+++ b/graphkit/network.py
@@ -455,6 +455,7 @@ def get_data_node(name, graph):
 
 
 def supported_plot_formats():
+    """return automatically all `pydot` extensions withlike ``.png``"""
     import pydot
 
     return [".%s" % f for f in pydot.Dot().formats]
@@ -524,8 +525,6 @@ def plot_graph(graph, filename=None, show=False, steps=None,
 
     """
     import pydot
-    import matplotlib.pyplot as plt
-    import matplotlib.image as mpimg
 
     assert graph is not None
 
@@ -610,6 +609,9 @@ def plot_graph(graph, filename=None, show=False, steps=None,
 
     # display graph via matplotlib
     if show:
+        import matplotlib.pyplot as plt
+        import matplotlib.image as mpimg
+
         png = g.create_png()
         sio = io.BytesIO(png)
         img = mpimg.imread(sio)

--- a/graphkit/network.py
+++ b/graphkit/network.py
@@ -422,23 +422,23 @@ class Network(object):
 
         # save plot
         if filename:
+            supported_plot_formaters = {
+                ".png": g.create_png,
+                ".dot": g.to_string,
+                ".jpg": g.create_jpeg,
+                ".jpeg": g.create_jpeg,
+                ".pdf": g.create_pdf,
+                ".svg": g.create_svg,
+            }
             _basename, ext = os.path.splitext(filename)
+            plot_formater = supported_plot_formaters.get(ext.lower())
+            if not plot_formater:
+                raise Exception(
+                    "Unknown file format for saving graph: %s"
+                    "  File extensions must be one of: .png .dot .jpg .jpeg .pdf .svg"
+                    % ext)
             with open(filename, "wb") as fh:
-                if ext.lower() == ".png":
-                    fh.write(g.create_png())
-                elif ext.lower() == ".dot":
-                    fh.write(g.to_string())
-                elif ext.lower() in [".jpg", ".jpeg"]:
-                    fh.write(g.create_jpeg())
-                elif ext.lower() == ".pdf":
-                    fh.write(g.create_pdf())
-                elif ext.lower() == ".svg":
-                    fh.write(g.create_svg())
-                else:
-                    raise Exception(
-                        "Unknown file format for saving graph: %s"
-                        "  File extensions must be one of: .png .dot .jpg .jpeg .pdf .svg"
-                        % ext)
+                fh.write(plot_formater())
 
         # display graph via matplotlib
         if show:

--- a/graphkit/network.py
+++ b/graphkit/network.py
@@ -453,8 +453,8 @@ def plot_graph(graph, filename=None, show=False, steps=None,
     :param graph:
         what to plot
     :param str filename:
-        Write the output to a png, pdf, or graphviz dot file. The extension
-        controls the output format.
+        Write the output to a file.
+        The extension must be one of: ``.png .dot .jpg .jpeg .pdf .svg``
     :param boolean show:
         If this is set to True, use matplotlib to show the graph diagram
         (Default: False)

--- a/graphkit/network.py
+++ b/graphkit/network.py
@@ -422,8 +422,8 @@ class Network(object):
 
         # save plot
         if filename:
-            basename, ext = os.path.splitext(filename)
-            with open(filename, "w") as fh:
+            _basename, ext = os.path.splitext(filename)
+            with open(filename, "wb") as fh:
                 if ext.lower() == ".png":
                     fh.write(g.create_png())
                 elif ext.lower() == ".dot":

--- a/graphkit/network.py
+++ b/graphkit/network.py
@@ -382,7 +382,7 @@ class Network(object):
         :param str filename:
             Write diagram into a file.
             Common extensions are ``.png .dot .jpg .jpeg .pdf .svg``
-            call :func:`network.supported_plot_formats()` for more.
+            call :func:`plot.supported_plot_formats()` for more.
         :param show:
             If it evaluates to true, opens the  diagram in a  matplotlib window.
             If it equals `-1``, it plots but does not open the Window.

--- a/graphkit/network.py
+++ b/graphkit/network.py
@@ -450,6 +450,23 @@ def plot_graph(graph, filename=None, show=False, steps=None,
     """
     Plot a *Graphviz* graph/steps and return it, if no other argument provided.
 
+    Legend:
+
+    NODES:
+
+    - **circle**: function
+    - **house**: input (given)
+    - **inversed-house**: output (asked)
+    - **polygon**: given both as input & asked as output (what?)
+    - **square**: intermediate data (neither given nor asked)
+    - **red frame**: delete-instruction (to free up memory)
+
+    ARROWS
+
+    - **solid black arrows**: dependencies (target ``need`` source, 
+      sources ``provide`` target)
+    - **green-dotted arrows**: execution steps labeled in succession
+
     :param graph:
         what to plot
     :param str filename:
@@ -470,6 +487,18 @@ def plot_graph(graph, filename=None, show=False, steps=None,
 
     :returns:
         An instance of the pydot graph
+
+    **Example:**
+
+    >>> netop = compose(name="netop")(
+    ...     operation(name="add", needs=["a", "b1"], provides=["ab1"])(add),
+    ...     operation(name="sub", needs=["a", optional("b2")], provides=["ab2"])(lambda a, b=1: a-b),
+    ...     operation(name="abb", needs=["ab1", "ab2"], provides=["asked"])(add),
+    ... )
+
+    >>> inputs = {'a': 1, 'b1': 2}
+    >>> solution=netop(inputs)
+    >>> netop.plot('plot.svg', inputs=inputs, solution=solution, outputs=['asked', 'b1']);
 
     """
     import pydot

--- a/graphkit/network.py
+++ b/graphkit/network.py
@@ -496,6 +496,7 @@ def plot_graph(graph, filename=None, show=False, steps=None,
         call :func:`network.supported_plot_formats()` for more.
     :param boolean show:
         If it evaluates to true, opens the  diagram in a  matplotlib window.
+        If it equals ``-1``, it plots but does not open the Window.
     :param steps:
         a list of nodes & instructions to overlay on the diagram
     :param inputs:
@@ -616,6 +617,7 @@ def plot_graph(graph, filename=None, show=False, steps=None,
         sio = io.BytesIO(png)
         img = mpimg.imread(sio)
         plt.imshow(img, aspect="equal")
-        plt.show()
+        if show != -1:
+            plt.show()
 
     return g

--- a/graphkit/network.py
+++ b/graphkit/network.py
@@ -435,7 +435,10 @@ class Network(object):
                 elif ext.lower() == ".svg":
                     fh.write(g.create_svg())
                 else:
-                    raise Exception("Unknown file format for saving graph: %s" % ext)
+                    raise Exception(
+                        "Unknown file format for saving graph: %s"
+                        "  File extensions must be one of: .png .dot .jpg .jpeg .pdf .svg"
+                        % ext)
 
         # display graph via matplotlib
         if show:

--- a/graphkit/network.py
+++ b/graphkit/network.py
@@ -1,13 +1,11 @@
 # Copyright 2016, Yahoo Inc.
 # Licensed under the terms of the Apache License, Version 2.0. See the LICENSE file associated with the project for terms.
 
-import io
-import os
 import time
 import networkx as nx
 
 
-from .base import Operation, NetworkOperation
+from .base import Operation
 from .modifiers import optional
 
 
@@ -404,9 +402,11 @@ class Network(object):
         :return:
             An instance of the :mod`pydot` graph
 
-        See :func:`network.plot_graph` for the plot legend and example code.
+        See :func:`graphkit.plot.plot_graph()` for the plot legend and example code.
         """
-        return plot_graph(self.graph, filename, show, jupyter,
+        from . import plot
+        
+        return plot.plot_graph(self.graph, filename, show, jupyter,
                           self.steps, inputs, outputs, solution)
 
 
@@ -463,179 +463,3 @@ def supported_plot_formats():
     import pydot
 
     return [".%s" % f for f in pydot.Dot().formats]
-
-
-def plot_graph(graph, filename=None, show=False, jupyter=False,
-               steps=None, inputs=None, outputs=None, solution=None):
-    """
-    Plot a *Graphviz* graph/steps and return it, if no other argument provided.
-
-    Legend:
-
-
-    NODES:
-
-    - **circle**: function
-    - **oval**: subgraph function
-    - **house**: given input
-    - **inversed-house**: asked output
-    - **polygon**: given both as input & asked as output (what?)
-    - **square**: intermediate data, neither given nor asked.
-    - **red frame**: delete-instruction, to free up memory.
-    - **filled**: data node has a value in `solution`, shown in tooltip.
-    - **thick frame**: function/data node visited.
-
-    ARROWS
-
-    - **solid black arrows**: dependencies (source-data are``need``\ed
-      by target-operations, sources-operations ``provide`` target-data)
-    - **dashed black arrows**: optional needs
-    - **green-dotted arrows**: execution steps labeled in succession
-
-    :param graph:
-        what to plot
-    :param str filename:
-        Write diagram into a file.
-        Common extensions are ``.png .dot .jpg .jpeg .pdf .svg``
-        call :func:`network.supported_plot_formats()` for more.
-    :param show:
-        If it evaluates to true, opens the  diagram in a  matplotlib window.
-        If it equals `-1``, it plots but does not open the Window.
-    :param jupyter:
-        If it evaluates to true, return an SVG suitable to render 
-        in *jupyter notebook cells* (`ipython` must be installed).
-    :param steps:
-        a list of nodes & instructions to overlay on the diagram
-    :param inputs:
-        an optional name list, any nodes in there are plotted
-        as a "house"
-    :param outputs:
-        an optional name list, any nodes in there are plotted
-        as an "inverted-house"
-    :param solution:
-        an optional dict with values to annotate nodes
-        (currently content not shown, but node drawn as "filled")
-
-    :return:
-        An instance of the :mod`pydot` graph
-
-    **Example:**
-
-    >>> from graphkit import compose, operation
-    >>> from graphkit.modifiers import optional
-
-    >>> pipeline = compose(name="pipeline")(
-    ...     operation(name="add", needs=["a", "b1"], provides=["ab1"])(add),
-    ...     operation(name="sub", needs=["a", optional("b2")], provides=["ab2"])(lambda a, b=1: a-b),
-    ...     operation(name="abb", needs=["ab1", "ab2"], provides=["asked"])(add),
-    ... )
-
-    >>> inputs = {'a': 1, 'b1': 2}
-    >>> solution=pipeline(inputs)
-    >>> pipeline.plot('plot.svg', inputs=inputs, solution=solution, outputs=['asked', 'b1']);
-
-    """
-    import pydot
-
-    assert graph is not None
-
-    def get_node_name(a):
-        if isinstance(a, Operation):
-            return a.name
-        return a
-
-    g = pydot.Dot(graph_type="digraph")
-
-    # draw nodes
-    for nx_node in graph.nodes:
-        kw = {}
-        if isinstance(nx_node, str):
-            # Only DeleteInstructions data in steps.
-            if nx_node in steps:
-                kw = {'color': 'red', 'penwidth': 2}
-
-            # SHAPE change if in inputs/outputs.
-            # tip: https://graphviz.gitlab.io/_pages/doc/info/shapes.html
-            shape="rect"
-            if inputs and outputs and nx_node in inputs and nx_node in outputs:
-                shape="hexagon"
-            else:
-                if inputs and nx_node in inputs:
-                    shape="invhouse"
-                if outputs and nx_node in outputs:
-                    shape="house"
-
-            # LABEL change from solution.
-            if solution and nx_node in solution:
-                kw["style"] = "filled"
-                kw["fillcolor"] = "gray"
-                # kw["tooltip"] = nx_node, solution.get(nx_node)
-            node = pydot.Node(name=nx_node, shape=shape,
-            URL="fdgfdf", **kw)
-        else:  # Operation
-            kw = {}
-            shape = "oval" if isinstance(nx_node, NetworkOperation) else "circle"
-            if nx_node in steps:
-                kw["style"] = "bold"
-            node = pydot.Node(name=nx_node.name, shape=shape, **kw)
-
-        g.add_node(node)
-
-    # draw edges
-    for src, dst in graph.edges:
-        src_name = get_node_name(src)
-        dst_name = get_node_name(dst)
-        kw = {}
-        if isinstance(dst, Operation) and any(n == src
-                                              and isinstance(n, optional)
-                                              for n in dst.needs):
-            kw["style"] = "dashed"
-        edge = pydot.Edge(src=src_name, dst=dst_name, **kw)
-        g.add_edge(edge)
-
-    # draw steps sequence
-    if steps and len(steps) > 1:
-        it1 = iter(steps)
-        it2 = iter(steps); next(it2)
-        for i, (src, dst) in enumerate(zip(it1, it2), 1):
-            src_name = get_node_name(src)
-            dst_name = get_node_name(dst)
-            edge = pydot.Edge(
-                src=src_name, dst=dst_name, label=str(i), style='dotted',
-                color="green", fontcolor="green", fontname="bold", fontsize=18,
-                penwidth=3, arrowhead="vee")
-            g.add_edge(edge)
-
-    # Save plot
-    #
-    if filename:
-        formats = supported_plot_formats()
-        _basename, ext = os.path.splitext(filename)
-        if not ext.lower() in formats:
-            raise ValueError(
-                "Unknown file format for saving graph: %s"
-                "  File extensions must be one of: %s"
-                % (ext, " ".join(formats)))
-
-        g.write(filename, format=ext.lower()[1:])
-
-    ## Return an SVG renderable in jupyter.
-    #
-    if jupyter:
-        from IPython.display import SVG
-        g = SVG(data=g.create_svg())
-
-    ## Display graph via matplotlib
-    #
-    if show:
-        import matplotlib.pyplot as plt
-        import matplotlib.image as mpimg
-
-        png = g.create_png()
-        sio = io.BytesIO(png)
-        img = mpimg.imread(sio)
-        plt.imshow(img, aspect="equal")
-        if show != -1:
-            plt.show()
-
-    return g

--- a/graphkit/network.py
+++ b/graphkit/network.py
@@ -1,8 +1,9 @@
 # Copyright 2016, Yahoo Inc.
 # Licensed under the terms of the Apache License, Version 2.0. See the LICENSE file associated with the project for terms.
 
-import time
+import io
 import os
+import time
 import networkx as nx
 
 from io import StringIO
@@ -505,7 +506,7 @@ def plot_graph(graph, filename=None, show=False):
     # display graph via matplotlib
     if show:
         png = g.create_png()
-        sio = StringIO(png)
+        sio = io.BytesIO(png)
         img = mpimg.imread(sio)
         plt.imshow(img, aspect="equal")
         plt.show()

--- a/graphkit/network.py
+++ b/graphkit/network.py
@@ -383,8 +383,8 @@ class Network(object):
 
         :param str filename:
             Write diagram into a file.
-            The extension must be one of: ``.png .dot .jpg .jpeg .pdf .svg``
-            Prefer ``.pdf`` or ``.svg`` to see solution-values in tooltips.
+            Common extensions are ``.png .dot .jpg .jpeg .pdf .svg``
+            call :func:`network.supported_plot_formats()` for more.
         :param boolean show:
             If it evaluates to true, opens the  diagram in a  matplotlib window.
         :param inputs:
@@ -454,15 +454,10 @@ def get_data_node(name, graph):
     return None
 
 
-def supported_plot_writers():
-    return {
-        ".png": lambda gplot: gplot.create_png(),
-        ".dot": lambda gplot: gplot.to_string(),
-        ".jpg": lambda gplot: gplot.create_jpeg(),
-        ".jpeg": lambda gplot: gplot.create_jpeg(),
-        ".pdf": lambda gplot: gplot.create_pdf(),
-        ".svg": lambda gplot: gplot.create_svg(),
-    }
+def supported_plot_formats():
+    import pydot
+
+    return [".%s" % f for f in pydot.Dot().formats]
 
 
 def plot_graph(graph, filename=None, show=False, steps=None,
@@ -496,8 +491,8 @@ def plot_graph(graph, filename=None, show=False, steps=None,
         what to plot
     :param str filename:
         Write diagram into a file.
-        The extension must be one of: ``.png .dot .jpg .jpeg .pdf .svg``
-        Prefer ``.pdf`` or ``.svg`` to see solution-values in tooltips.
+        Common extensions are ``.png .dot .jpg .jpeg .pdf .svg``
+        call :func:`network.supported_plot_formats()` for more.
     :param boolean show:
         If it evaluates to true, opens the  diagram in a  matplotlib window.
     :param steps:
@@ -603,16 +598,15 @@ def plot_graph(graph, filename=None, show=False, steps=None,
 
     # save plot
     if filename:
+        formats = supported_plot_formats()
         _basename, ext = os.path.splitext(filename)
-        writers = supported_plot_writers()
-        plot_writer = supported_plot_writers().get(ext.lower())
-        if not plot_writer:
+        if not ext.lower() in formats:
             raise ValueError(
                 "Unknown file format for saving graph: %s"
                 "  File extensions must be one of: %s"
-                % (ext, ' '.join(writers)))
-        with open(filename, "wb") as fh:
-            fh.write(plot_writer(g))
+                % (ext, " ".join(formats)))
+
+        g.write(filename, format=ext.lower()[1:])
 
     # display graph via matplotlib
     if show:

--- a/graphkit/plot.py
+++ b/graphkit/plot.py
@@ -33,7 +33,7 @@ def build_pydot(graph, steps=None, inputs=None, outputs=None, solution=None):
         kw = {}
         if isinstance(nx_node, str):
             # Only DeleteInstructions data in steps.
-            if nx_node in steps:
+            if steps and nx_node in steps:
                 kw = {"color": "red", "penwidth": 2}
 
             # SHAPE change if in inputs/outputs.
@@ -129,7 +129,7 @@ def plot_graph(
 
     ARROWS
 
-    - **solid black arrows**: dependencies (source-data are``need``\ed
+    - **solid black arrows**: dependencies (source-data are``need``-ed
       by target-operations, sources-operations ``provide`` target-data)
     - **dashed black arrows**: optional needs
     - **green-dotted arrows**: execution steps labeled in succession

--- a/graphkit/plot.py
+++ b/graphkit/plot.py
@@ -1,0 +1,208 @@
+# Copyright 2016, Yahoo Inc.
+# Licensed under the terms of the Apache License, Version 2.0. See the LICENSE file associated with the project for terms.
+
+import io
+import os
+
+from .base import NetworkOperation, Operation
+from .modifiers import optional
+
+
+def supported_plot_formats():
+    """return automatically all `pydot` extensions withlike ``.png``"""
+    import pydot
+
+    return [".%s" % f for f in pydot.Dot().formats]
+
+
+def plot_graph(
+    graph,
+    filename=None,
+    show=False,
+    jupyter=False,
+    steps=None,
+    inputs=None,
+    outputs=None,
+    solution=None,
+):
+    """
+    Plot a *Graphviz* graph/steps and return it, if no other argument provided.
+
+    Legend:
+
+
+    NODES:
+
+    - **circle**: function
+    - **oval**: subgraph function
+    - **house**: given input
+    - **inversed-house**: asked output
+    - **polygon**: given both as input & asked as output (what?)
+    - **square**: intermediate data, neither given nor asked.
+    - **red frame**: delete-instruction, to free up memory.
+    - **filled**: data node has a value in `solution`, shown in tooltip.
+    - **thick frame**: function/data node visited.
+
+    ARROWS
+
+    - **solid black arrows**: dependencies (source-data are``need``\ed
+      by target-operations, sources-operations ``provide`` target-data)
+    - **dashed black arrows**: optional needs
+    - **green-dotted arrows**: execution steps labeled in succession
+
+    :param graph:
+        what to plot
+    :param str filename:
+        Write diagram into a file.
+        Common extensions are ``.png .dot .jpg .jpeg .pdf .svg``
+        call :func:`network.supported_plot_formats()` for more.
+    :param show:
+        If it evaluates to true, opens the  diagram in a  matplotlib window.
+        If it equals `-1``, it plots but does not open the Window.
+    :param jupyter:
+        If it evaluates to true, return an SVG suitable to render 
+        in *jupyter notebook cells* (`ipython` must be installed).
+    :param steps:
+        a list of nodes & instructions to overlay on the diagram
+    :param inputs:
+        an optional name list, any nodes in there are plotted
+        as a "house"
+    :param outputs:
+        an optional name list, any nodes in there are plotted
+        as an "inverted-house"
+    :param solution:
+        an optional dict with values to annotate nodes
+        (currently content not shown, but node drawn as "filled")
+
+    :return:
+        An instance of the :mod`pydot` graph
+
+    **Example:**
+
+    >>> from graphkit import compose, operation
+    >>> from graphkit.modifiers import optional
+
+    >>> pipeline = compose(name="pipeline")(
+    ...     operation(name="add", needs=["a", "b1"], provides=["ab1"])(add),
+    ...     operation(name="sub", needs=["a", optional("b2")], provides=["ab2"])(lambda a, b=1: a-b),
+    ...     operation(name="abb", needs=["ab1", "ab2"], provides=["asked"])(add),
+    ... )
+
+    >>> inputs = {'a': 1, 'b1': 2}
+    >>> solution=pipeline(inputs)
+    >>> pipeline.plot('plot.svg', inputs=inputs, solution=solution, outputs=['asked', 'b1']);
+
+    """
+    import pydot
+
+    assert graph is not None
+
+    def get_node_name(a):
+        if isinstance(a, Operation):
+            return a.name
+        return a
+
+    g = pydot.Dot(graph_type="digraph")
+
+    # draw nodes
+    for nx_node in graph.nodes:
+        kw = {}
+        if isinstance(nx_node, str):
+            # Only DeleteInstructions data in steps.
+            if nx_node in steps:
+                kw = {"color": "red", "penwidth": 2}
+
+            # SHAPE change if in inputs/outputs.
+            # tip: https://graphviz.gitlab.io/_pages/doc/info/shapes.html
+            shape = "rect"
+            if inputs and outputs and nx_node in inputs and nx_node in outputs:
+                shape = "hexagon"
+            else:
+                if inputs and nx_node in inputs:
+                    shape = "invhouse"
+                if outputs and nx_node in outputs:
+                    shape = "house"
+
+            # LABEL change from solution.
+            if solution and nx_node in solution:
+                kw["style"] = "filled"
+                kw["fillcolor"] = "gray"
+                # kw["tooltip"] = nx_node, solution.get(nx_node)
+            node = pydot.Node(name=nx_node, shape=shape, URL="fdgfdf", **kw)
+        else:  # Operation
+            kw = {}
+            shape = "oval" if isinstance(nx_node, NetworkOperation) else "circle"
+            if nx_node in steps:
+                kw["style"] = "bold"
+            node = pydot.Node(name=nx_node.name, shape=shape, **kw)
+
+        g.add_node(node)
+
+    # draw edges
+    for src, dst in graph.edges:
+        src_name = get_node_name(src)
+        dst_name = get_node_name(dst)
+        kw = {}
+        if isinstance(dst, Operation) and any(
+            n == src and isinstance(n, optional) for n in dst.needs
+        ):
+            kw["style"] = "dashed"
+        edge = pydot.Edge(src=src_name, dst=dst_name, **kw)
+        g.add_edge(edge)
+
+    # draw steps sequence
+    if steps and len(steps) > 1:
+        it1 = iter(steps)
+        it2 = iter(steps)
+        next(it2)
+        for i, (src, dst) in enumerate(zip(it1, it2), 1):
+            src_name = get_node_name(src)
+            dst_name = get_node_name(dst)
+            edge = pydot.Edge(
+                src=src_name,
+                dst=dst_name,
+                label=str(i),
+                style="dotted",
+                color="green",
+                fontcolor="green",
+                fontname="bold",
+                fontsize=18,
+                penwidth=3,
+                arrowhead="vee",
+            )
+            g.add_edge(edge)
+
+    # Save plot
+    #
+    if filename:
+        formats = supported_plot_formats()
+        _basename, ext = os.path.splitext(filename)
+        if not ext.lower() in formats:
+            raise ValueError(
+                "Unknown file format for saving graph: %s"
+                "  File extensions must be one of: %s" % (ext, " ".join(formats))
+            )
+
+        g.write(filename, format=ext.lower()[1:])
+
+    ## Return an SVG renderable in jupyter.
+    #
+    if jupyter:
+        from IPython.display import SVG
+
+        g = SVG(data=g.create_svg())
+
+    ## Display graph via matplotlib
+    #
+    if show:
+        import matplotlib.pyplot as plt
+        import matplotlib.image as mpimg
+
+        png = g.create_png()
+        sio = io.BytesIO(png)
+        img = mpimg.imread(sio)
+        plt.imshow(img, aspect="equal")
+        if show != -1:
+            plt.show()
+
+    return g

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,16 @@ and many other domains.
 with io.open('graphkit/__init__.py', 'rt', encoding='utf8') as f:
     version = re.search(r'__version__ = \'(.*?)\'', f.read()).group(1)
 
+plot_reqs = [
+     "ipython; python_version >= '3.5'",     # to test jupyter plot.
+     "matplotlib",   # to test plot
+     "pydot",        # to test plot
+]
+test_reqs = plot_reqs + [
+     "pytest",
+     "pytest-cov",
+]
+
 setup(
      name='graphkit',
      version=version,
@@ -33,16 +43,10 @@ setup(
           "networkx == 2.2; python_version < '3.5'",
      ],
      extras_require={
-          'plot': ['pydot', 'matplotlib'],
-          'test': ['pydot', 'matplotlib', 'pytest', "pytest-cov"],
+          'plot': plot_reqs,
+          'test': test_reqs,
      },
-     tests_require=[
-          "pytest",
-          "pytest-cov",
-          "ipython; python_version >= '3.5'",     # to test jupyter plot.
-          "pydot",       # to test plot
-          "matplotlib"   # to test plot
-     ],
+     tests_require=test_reqs,
      license='Apache-2.0',
      keywords=['graph', 'computation graph', 'DAG', 'directed acyclical graph'],
      classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,10 @@ setup(
      author_email='huyng@yahoo-inc.com',
      url='http://github.com/yahoo/graphkit',
      packages=['graphkit'],
-     install_requires=['networkx'],
+     install_requires=[
+          "networkx; python_version >= '3.5'",
+          "networkx == 2.2; python_version < '3.5'",
+     ],
      extras_require={
           'plot': ['pydot', 'matplotlib']
      },

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ setup(
           "networkx == 2.2; python_version < '3.5'",
      ],
      extras_require={
-          'plot': ['pydot', 'matplotlib']
+          'plot': ['pydot', 'matplotlib'],
+          'test': ['pydot', 'matplotlib', 'pytest'],
      },
      tests_require=['pytest'],
      license='Apache-2.0',

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
      },
      tests_require=[
           "numpy",
+          "ipython; python_version >= '3.5'",     # to test jupyter plot.
           "pydot",       # to test plot
           "matplotlib"   # to test plot
      ],

--- a/setup.py
+++ b/setup.py
@@ -34,9 +34,9 @@ setup(
      ],
      extras_require={
           'plot': ['pydot', 'matplotlib'],
-          'test': ['pydot', 'matplotlib', 'pytest'],
+          'test': ['pydot', 'matplotlib', 'pytest', "pytest-cov"],
      },
-     tests_require=['pytest'],
+     tests_require=['pytest', "pytest-cov"],
      license='Apache-2.0',
      keywords=['graph', 'computation graph', 'DAG', 'directed acyclical graph'],
      classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
      extras_require={
           'plot': ['pydot', 'matplotlib']
      },
-     tests_require=['numpy'],
+     tests_require=['pytest'],
      license='Apache-2.0',
      keywords=['graph', 'computation graph', 'DAG', 'directed acyclical graph'],
      classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,11 @@ setup(
      extras_require={
           'plot': ['pydot', 'matplotlib']
      },
-     tests_require=['numpy'],
+     tests_require=[
+          "numpy",
+          "pydot",       # to test plot
+          "matplotlib"   # to test plot
+     ],
      license='Apache-2.0',
      keywords=['graph', 'computation graph', 'DAG', 'directed acyclical graph'],
      classifiers=[

--- a/test/test_graphkit.py
+++ b/test/test_graphkit.py
@@ -327,7 +327,7 @@ def test_plotting():
     sum_op3 = operation(name='sum_op3', needs=['sum1', 'c'], provides='sum3')(add)
     net1 = compose(name='my network 1')(sum_op1, sum_op2, sum_op3)
 
-    for ext in network.Network.supported_plot_writers():
+    for ext in network.supported_plot_writers():
         tdir = tempfile.mkdtemp(suffix=ext)
         png_file = osp.join(tdir, "workflow.png")
         net1.net.plot(png_file)
@@ -342,7 +342,7 @@ def test_plotting():
         assert "Unknown file format" in str(ex)
 
         ## Check help msg lists all siupported formats
-        for ext in network.Network.supported_plot_writers():
+        for ext in network.supported_plot_writers():
             assert ext in str(ex)
 
 

--- a/test/test_graphkit.py
+++ b/test/test_graphkit.py
@@ -327,7 +327,7 @@ def test_plotting():
     sum_op3 = operation(name='sum_op3', needs=['sum1', 'c'], provides='sum3')(add)
     net1 = compose(name='my network 1')(sum_op1, sum_op2, sum_op3)
 
-    for ext in ".png .dot .jpg .jpeg .pdf .svg".split():
+    for ext in network.Network.supported_plot_writers():
         tdir = tempfile.mkdtemp(suffix=ext)
         png_file = osp.join(tdir, "workflow.png")
         net1.net.plot(png_file)
@@ -335,6 +335,15 @@ def test_plotting():
             assert osp.exists(png_file)
         finally:
             shutil.rmtree(tdir, ignore_errors=True)
+    try:
+        net1.net.plot('bad.format')
+        assert False, "Should had failed writting arbitrary file format!"
+    except ValueError as ex:
+        assert "Unknown file format" in str(ex)
+
+        ## Check help msg lists all siupported formats
+        for ext in network.Network.supported_plot_writers():
+            assert ext in str(ex)
 
 
 ####################################

--- a/test/test_graphkit.py
+++ b/test/test_graphkit.py
@@ -139,7 +139,8 @@ def test_plotting():
     finally:
         shutil.rmtree(tdir, ignore_errors=True)
 
-    ## Don't open matplotlib window.
+    ## Try matplotlib Window, but
+    # without opening a Window.
     #
     if sys.version_info < (3, 5):
         # On PY< 3.5 it fails with:
@@ -149,6 +150,12 @@ def test_plotting():
         matplotlib.use("Agg")
     # do not open window in headless travis
     assert pipeline.plot(show=-1)
+
+    ## Try Jupyter SVG.
+    #
+    # but latest ipython-7+ dropped < PY3.4
+    if sys.version_info >= (3, 5):
+        assert "display.SVG" in str(type(pipeline.plot(jupyter=True)))
 
     try:
         pipeline.plot('bad.format')

--- a/test/test_graphkit.py
+++ b/test/test_graphkit.py
@@ -107,6 +107,31 @@ def test_network_deep_merge():
     pprint(net3({'a': 1, 'b': 2, 'c': 4}))
 
 
+def test_plotting():
+    sum_op1 = operation(name='sum_op1', needs=['a', 'b'], provides='sum1')(add)
+    sum_op2 = operation(name='sum_op2', needs=['a', 'b'], provides='sum2')(add)
+    sum_op3 = operation(name='sum_op3', needs=['sum1', 'c'], provides='sum3')(add)
+    net1 = compose(name='my network 1')(sum_op1, sum_op2, sum_op3)
+
+    for ext in network.supported_plot_writers():
+        tdir = tempfile.mkdtemp(suffix=ext)
+        png_file = osp.join(tdir, "workflow.png")
+        net1.net.plot(png_file)
+        try:
+            assert osp.exists(png_file)
+        finally:
+            shutil.rmtree(tdir, ignore_errors=True)
+    try:
+        net1.net.plot('bad.format')
+        assert False, "Should had failed writting arbitrary file format!"
+    except ValueError as ex:
+        assert "Unknown file format" in str(ex)
+
+        ## Check help msg lists all siupported formats
+        for ext in network.supported_plot_writers():
+            assert ext in str(ex)
+
+
 def test_input_based_pruning():
     # Tests to make sure we don't need to pass graph inputs if we're provided
     # with data further downstream in the graph as an input.
@@ -319,31 +344,6 @@ def test_multi_threading():
         pool = Pool(i)
         pool.map(infer, range(N))
         pool.close()
-
-
-def test_plotting():
-    sum_op1 = operation(name='sum_op1', needs=['a', 'b'], provides='sum1')(add)
-    sum_op2 = operation(name='sum_op2', needs=['a', 'b'], provides='sum2')(add)
-    sum_op3 = operation(name='sum_op3', needs=['sum1', 'c'], provides='sum3')(add)
-    net1 = compose(name='my network 1')(sum_op1, sum_op2, sum_op3)
-
-    for ext in network.supported_plot_writers():
-        tdir = tempfile.mkdtemp(suffix=ext)
-        png_file = osp.join(tdir, "workflow.png")
-        net1.net.plot(png_file)
-        try:
-            assert osp.exists(png_file)
-        finally:
-            shutil.rmtree(tdir, ignore_errors=True)
-    try:
-        net1.net.plot('bad.format')
-        assert False, "Should had failed writting arbitrary file format!"
-    except ValueError as ex:
-        assert "Unknown file format" in str(ex)
-
-        ## Check help msg lists all siupported formats
-        for ext in network.supported_plot_writers():
-            assert ext in str(ex)
 
 
 ####################################

--- a/test/test_graphkit.py
+++ b/test/test_graphkit.py
@@ -117,25 +117,35 @@ def test_plotting():
     inputs = {'a': 1, 'b1': 2}
     solution=pipeline(inputs)
 
-    # ...not working on my PC ...
+
+    ## Generate all formats
+    #  (not needing to save files)
+    #
+    # ...these are not working on my PC, or travis.
     forbidden_formats = ".dia .hpgl .mif .mp .pcl .pic .vtx .xlib".split()
+    prev_dot = None
+    for ext in network.supported_plot_formats():
+        if ext in forbidden_formats:
+            continue
 
+        dot = pipeline.plot(inputs=inputs, solution=solution, outputs=['asked', 'b1'])
+        assert dot
+        assert dot != prev_dot
+        prev_dot = dot
+
+        dot = pipeline.plot()
+        assert dot
+        assert dot != prev_dot
+        prev_dot = dot
+
+    ## Try saving one file.
+    #
     tdir = tempfile.mkdtemp()
-    counter = 0
+    fpath = osp.join(tdir, "workflow.png")
     try:
-        for ext in network.supported_plot_formats():
-            if ext in forbidden_formats:
-                continue
-
-            counter += 1
-            fpath = osp.join(tdir, "workflow-%i%s" % (counter, ext))
-            pipeline.plot(fpath, inputs=inputs, solution=solution, outputs=['asked', 'b1'])
-            assert osp.exists(fpath)
-
-            counter += 1
-            fpath = osp.join(tdir, "workflow-%i%s" % (counter, ext))
-            pipeline.plot(fpath)
-            assert osp.exists(fpath)
+        dot = pipeline.plot(fpath, inputs=inputs, solution=solution, outputs=['asked', 'b1'])
+        assert osp.exists(fpath)
+        assert dot
     finally:
         shutil.rmtree(tdir, ignore_errors=True)
 

--- a/test/test_graphkit.py
+++ b/test/test_graphkit.py
@@ -3,6 +3,10 @@
 
 import math
 import pickle
+import os.path as osp
+import shutil
+import tempfile
+
 
 from pprint import pprint
 from operator import add
@@ -315,6 +319,22 @@ def test_multi_threading():
         pool = Pool(i)
         pool.map(infer, range(N))
         pool.close()
+
+
+def test_plotting():
+    sum_op1 = operation(name='sum_op1', needs=['a', 'b'], provides='sum1')(add)
+    sum_op2 = operation(name='sum_op2', needs=['a', 'b'], provides='sum2')(add)
+    sum_op3 = operation(name='sum_op3', needs=['sum1', 'c'], provides='sum3')(add)
+    net1 = compose(name='my network 1')(sum_op1, sum_op2, sum_op3)
+
+    for ext in ".png .dot .jpg .jpeg .pdf .svg".split():
+        tdir = tempfile.mkdtemp(suffix=ext)
+        png_file = osp.join(tdir, "workflow.png")
+        net1.net.plot(png_file)
+        try:
+            assert osp.exists(png_file)
+        finally:
+            shutil.rmtree(tdir, ignore_errors=True)
 
 
 ####################################

--- a/test/test_graphkit.py
+++ b/test/test_graphkit.py
@@ -117,7 +117,8 @@ def test_plotting():
     solution=pipeline(inputs)
 
     # ...not working on my PC ...
-    forbidden_formats = ".dia .hpgl .mif .pcl .pic .vtx .xlib".split()
+    forbidden_formats = ".dia .hpgl .mif .mp .pcl .pic .vtx .xlib".split()
+
     tdir = tempfile.mkdtemp()
     counter = 0
     try:

--- a/test/test_graphkit.py
+++ b/test/test_graphkit.py
@@ -116,14 +116,27 @@ def test_plotting():
     inputs = {'a': 1, 'b1': 2}
     solution=pipeline(inputs)
 
-    for ext in network.supported_plot_writers():
-        tdir = tempfile.mkdtemp(suffix=ext)
-        png_file = osp.join(tdir, "workflow.png")
-        pipeline.plot(png_file, inputs=inputs, solution=solution, outputs=['asked', 'b1'])
-        try:
-            assert osp.exists(png_file)
-        finally:
-            shutil.rmtree(tdir, ignore_errors=True)
+    # ...not working on my PC ...
+    forbidden_formats = ".dia .hpgl .mif .pcl .pic .vtx .xlib".split()
+    tdir = tempfile.mkdtemp()
+    counter = 0
+    try:
+        for ext in network.supported_plot_formats():
+            if ext in forbidden_formats:
+                continue
+
+            counter += 1
+            fpath = osp.join(tdir, "workflow-%i%s" % (counter, ext))
+            pipeline.plot(fpath, inputs=inputs, solution=solution, outputs=['asked', 'b1'])
+            assert osp.exists(fpath)
+
+            counter += 1
+            fpath = osp.join(tdir, "workflow-%i%s" % (counter, ext))
+            pipeline.plot(fpath)
+            assert osp.exists(fpath)
+    finally:
+        shutil.rmtree(tdir, ignore_errors=True)
+
     try:
         pipeline.plot('bad.format')
         assert False, "Should had failed writting arbitrary file format!"
@@ -131,12 +144,13 @@ def test_plotting():
         assert "Unknown file format" in str(ex)
 
         ## Check help msg lists all siupported formats
-        for ext in network.supported_plot_writers():
+        for ext in network.supported_plot_formats():
             assert ext in str(ex)
 
 
 def test_plotting_docstring():
-    for ext in network.supported_plot_writers():
+    common_formats = ".png .dot .jpg .jpeg .pdf .svg".split()
+    for ext in common_formats:
         assert ext in network.plot_graph.__doc__
 
 

--- a/test/test_graphkit.py
+++ b/test/test_graphkit.py
@@ -132,6 +132,11 @@ def test_plotting():
             assert ext in str(ex)
 
 
+def test_plotting_docstring():
+    for ext in network.supported_plot_writers():
+        assert ext in network.plot_graph.__doc__
+
+
 def test_input_based_pruning():
     # Tests to make sure we don't need to pass graph inputs if we're provided
     # with data further downstream in the graph as an input.

--- a/test/test_graphkit.py
+++ b/test/test_graphkit.py
@@ -6,7 +6,8 @@ import pickle
 
 from pprint import pprint
 from operator import add
-from numpy.testing import assert_raises
+
+import pytest
 
 import graphkit.network as network
 import graphkit.modifiers as modifiers
@@ -180,9 +181,10 @@ def test_pruning_raises_for_bad_output():
 
     # Request two outputs we can compute and one we can't compute.  Assert
     # that this raises a ValueError.
-    assert_raises(ValueError, net, {'a': 1, 'b': 2, 'c': 3, 'd': 4},
-        outputs=['sum1', 'sum3', 'sum4'])
-
+    with pytest.raises(ValueError) as exinfo:
+        net({'a': 1, 'b': 2, 'c': 3, 'd': 4},
+            outputs=['sum1', 'sum3', 'sum4'])
+    assert exinfo.match('sum4')
 
 def test_optional():
     # Test that optional() needs work as expected.

--- a/test/test_graphkit.py
+++ b/test/test_graphkit.py
@@ -5,6 +5,7 @@ import math
 import pickle
 import os.path as osp
 import shutil
+import sys
 import tempfile
 
 
@@ -137,6 +138,17 @@ def test_plotting():
             assert osp.exists(fpath)
     finally:
         shutil.rmtree(tdir, ignore_errors=True)
+
+    ## Don't open matplotlib window.
+    #
+    if sys.version_info < (3, 5):
+        # On PY< 3.5 it fails with:
+        #   nose.proxy.TclError: no display name and no $DISPLAY environment variable
+        # eg https://travis-ci.org/ankostis/graphkit/jobs/593957996
+        import matplotlib
+        matplotlib.use("Agg")
+    # do not open window in headless travis
+    assert pipeline.plot(show=-1)
 
     try:
         pipeline.plot('bad.format')

--- a/test/test_plot.py
+++ b/test/test_plot.py
@@ -1,12 +1,12 @@
 # Copyright 2016, Yahoo Inc.
 # Licensed under the terms of the Apache License, Version 2.0. See the LICENSE file associated with the project for terms.
 
+import sys
 from operator import add
 
 import pytest
-import sys
 
-from graphkit import compose, network, operation
+from graphkit import base, compose, network, operation, plot
 from graphkit.modifiers import optional
 
 
@@ -48,7 +48,9 @@ def solution(pipeline, inputs, outputs, request):
 def test_plotting_docstring():
     common_formats = ".png .dot .jpg .jpeg .pdf .svg".split()
     for ext in common_formats:
-        assert ext in network.plot_graph.__doc__
+        assert ext in plot.plot_graph.__doc__
+        assert ext in base.NetworkOperation.plot.__doc__
+        assert ext in network.Network.plot.__doc__
 
 
 def test_plot_formats(pipeline, input_names, outputs, solution, tmp_path):

--- a/test/test_plot.py
+++ b/test/test_plot.py
@@ -59,7 +59,7 @@ def test_plot_formats(pipeline, input_names, outputs, solution, tmp_path):
     # ...these are not working on my PC, or travis.
     forbidden_formats = ".dia .hpgl .mif .mp .pcl .pic .vtx .xlib".split()
     prev_dot = None
-    for ext in network.supported_plot_formats():
+    for ext in plot.supported_plot_formats():
         if ext not in forbidden_formats:
             dot = pipeline.plot(inputs=input_names, outputs=outputs, solution=solution)
             assert dot
@@ -72,7 +72,7 @@ def test_plot_bad_format(pipeline, tmp_path):
         pipeline.plot(filename="bad.format")
 
     ## Check help msg lists all siupported formats
-    for ext in network.supported_plot_formats():
+    for ext in plot.supported_plot_formats():
         assert exinfo.match(ext)
 
 

--- a/test/test_plot.py
+++ b/test/test_plot.py
@@ -1,0 +1,106 @@
+# Copyright 2016, Yahoo Inc.
+# Licensed under the terms of the Apache License, Version 2.0. See the LICENSE file associated with the project for terms.
+
+from operator import add
+
+import pytest
+import sys
+
+from graphkit import compose, network, operation
+from graphkit.modifiers import optional
+
+
+@pytest.fixture
+def pipeline():
+    return compose(name="netop")(
+        operation(name="add", needs=["a", "b1"], provides=["ab1"])(add),
+        operation(name="sub", needs=["a", optional("b2")], provides=["ab2"])(
+            lambda a, b=1: a - b
+        ),
+        operation(name="abb", needs=["ab1", "ab2"], provides=["asked"])(add),
+    )
+
+
+@pytest.fixture(params=[{"a": 1}, {"a": 1, "b1": 2}])
+def inputs(request):
+    return {"a": 1, "b1": 2}
+
+
+@pytest.fixture(params=[None, ("a", "b1")])
+def input_names(request):
+    return request.param
+
+
+@pytest.fixture(params=[None, ["asked", "b1"]])
+def outputs(request):
+    return request.param
+
+
+@pytest.fixture(params=[None, 1])
+def solution(pipeline, inputs, outputs, request):
+    return request.param and pipeline(inputs, outputs)
+
+
+###### TEST CASES #######
+##
+
+
+def test_plotting_docstring():
+    common_formats = ".png .dot .jpg .jpeg .pdf .svg".split()
+    for ext in common_formats:
+        assert ext in network.plot_graph.__doc__
+
+
+def test_plot_formats(pipeline, input_names, outputs, solution, tmp_path):
+    ## Generate all formats  (not needing to save files)
+
+    # ...these are not working on my PC, or travis.
+    forbidden_formats = ".dia .hpgl .mif .mp .pcl .pic .vtx .xlib".split()
+    prev_dot = None
+    for ext in network.supported_plot_formats():
+        if ext not in forbidden_formats:
+            dot = pipeline.plot(inputs=input_names, outputs=outputs, solution=solution)
+            assert dot
+            assert ext == ".jpg" or dot != prev_dot
+            prev_dot = dot
+
+
+def test_plot_bad_format(pipeline, tmp_path):
+    with pytest.raises(ValueError, match="Unknown file format") as exinfo:
+        pipeline.plot(filename="bad.format")
+
+    ## Check help msg lists all siupported formats
+    for ext in network.supported_plot_formats():
+        assert exinfo.match(ext)
+
+
+def test_plot_write_file(pipeline, tmp_path):
+    # Try saving a file from one format.
+
+    fpath = tmp_path / "workflow.png"
+
+    dot = pipeline.plot(str(fpath))
+    assert fpath.exists()
+    assert dot
+
+
+def test_plot_matplib(pipeline, tmp_path):
+    ## Try matplotlib Window, but # without opening a Window.
+
+    if sys.version_info < (3, 5):
+        # On PY< 3.5 it fails with:
+        #   nose.proxy.TclError: no display name and no $DISPLAY environment variable
+        # eg https://travis-ci.org/ankostis/graphkit/jobs/593957996
+        import matplotlib
+
+        matplotlib.use("Agg")
+    # do not open window in headless travis
+    assert pipeline.plot(show=-1)
+
+
+@pytest.mark.skipif(sys.version_info < (3, 5), reason="ipython-7+ dropped PY3.4-")
+def test_plot_jupyter(pipeline, tmp_path):
+    ## Try returned  Jupyter SVG.
+
+    dot = pipeline.plot(jupyter=True)
+    assert "display.SVG" in str(type(dot))


### PR DESCRIPTION
+ MERGED with #28 to parametrize tests.
+ FIX(plot): bring plot writing into files up-to-date from PY2 (were not opening in binary mode).
+ FIX(plot): do not open file if file-ext unsupported
+ FEAT: support render in Jupyter notebooks.
+ ENH: Overlay on the graph these elements:
  -execution-steps & order
  - inputs
  - outputs
  - solution values
  - "optional" needs:
+ TEST(plot): add TC for plot writing; needed to retrofit travis to support `graphvis` & `matplotb`.
+ REFACT: moved plot code & TCs into own files - split Graphviz building from IO functions.
+ enh(build): Test also *pip extras* now. 
+ doc: Just a minor but useful addition in the intro tutorial about plotting.

![t](https://user-images.githubusercontent.com/501585/66253793-2a19c580-e776-11e9-9803-4d711fe7b32f.png)

## Legend
### Nodes:

- **circle**: function
- **oval**: subgraph function
- **inversed-house**: given input
- **house**: asked output
- **polygon**: given both as input & asked as output (what?)
- **square**: intermediate data, neither given nor asked.
- **red frame**: delete-instruction, to free up memory.
- **filled**: data node has a value in `solution`, shown in tooltip.
- **thick frame**: function/data node visited.

### Arrows

- **solid black arrows**: dependencies (target ``need`` source,
    sources ``provide`` target)
- **dashed black arrows**: optional needs
- **green-dotted arrows**: execution steps labeled in succession

---
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
