### PR TITLE
FIX: invalidate execution-plan cache when dag modified

### DIFF
--- a/graphkit/network.py
+++ b/graphkit/network.py
@@ -73,6 +73,9 @@ class Network(object):
         # assert layer is only added once to graph
         assert operation not in self.graph.nodes(), "Operation may only be added once"
 
+        ## Invalidate old plans.
+        self._cached_execution_plans = {}
+
         # add nodes and edges to graph describing the data needs for this layer
         for n in operation.needs:
             self.graph.add_edge(DataPlaceholderNode(n), operation)

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,10 @@ setup(
      author_email='huyng@yahoo-inc.com',
      url='http://github.com/yahoo/graphkit',
      packages=['graphkit'],
-     install_requires=['networkx'],
+     install_requires=[
+          "networkx; python_version >= '3.5'",
+          "networkx == 2.2; python_version < '3.5'",
+     ],
      extras_require={
           'plot': ['pydot', 'matplotlib']
      },


### PR DESCRIPTION
Minor fix, encountered when building on top of composed networks & merges. 
---
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
