### PR TITLE
Improve error message when the graph contains cyclic dependencies

### DIFF
--- a/graphkit/network.py
+++ b/graphkit/network.py
@@ -122,8 +122,8 @@ class Network(object):
                 cycle = nx.find_cycle(self.graph)
             except nx.exception.NetworkXNoCycle:
                 raise ex
-            
-            raise Exception(f"Cyclic dependency in graph:\n{_format_cycle(cycle)}")
+            message = f"Cyclic dependency in graph:\n{_format_cycle(cycle)}"
+            raise nx.exception.NetworkXUnfeasible(message)
         # add Operations evaluation steps, and instructions to free data.
         for i, node in enumerate(ordered_nodes):
 

--- a/graphkit/network.py
+++ b/graphkit/network.py
@@ -27,6 +27,14 @@ class DeleteInstruction(str):
     def __repr__(self):
         return 'DeleteInstruction("%s")' % self
 
+def _format_cycle(cycle):
+    operation_strings = []
+    for second, first in reversed(cycle[1:] + [cycle[0]]):
+        if isinstance(first, DataPlaceholderNode) and operation_strings:
+            operation_strings[-1] += f' needs "{first}" from {second.name}.'
+        if isinstance(first, Operation):
+            operation_strings.append(first.name)
+    return "\n".join(operation_strings)
 
 class Network(object):
     """
@@ -107,8 +115,15 @@ class Network(object):
         self.steps = []
 
         # create an execution order such that each layer's needs are provided.
-        ordered_nodes = list(nx.dag.topological_sort(self.graph))
-
+        try:
+            ordered_nodes = list(nx.dag.topological_sort(self.graph))
+        except nx.exception.NetworkXUnfeasible as ex:
+            try:
+                cycle = nx.find_cycle(self.graph)
+            except nx.exception.NetworkXNoCycle:
+                raise ex
+            
+            raise Exception(f"Cyclic dependency in graph:\n{_format_cycle(cycle)}")
         # add Operations evaluation steps, and instructions to free data.
         for i, node in enumerate(ordered_nodes):
 


### PR DESCRIPTION
Creates a more helpful exception when trying to compose a graph with cyclic dependencies.

Example message: (helpful part at the bottom)

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'op3' is not defined
>>> graph = compose(name="graph")(op1, op2, op4)
Traceback (most recent call last):
  File "/home/jeremyiv/Documents/graphkit-1/graphkit/network.py", line 119, in compile
    ordered_nodes = list(nx.dag.topological_sort(self.graph))
  File "/home/jeremyiv/anaconda3/lib/python3.8/site-packages/networkx/algorithms/dag.py", line 210, in topological_sort
    raise nx.NetworkXUnfeasible("Graph contains a cycle or graph changed "
networkx.exception.NetworkXUnfeasible: Graph contains a cycle or graph changed during iteration

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jeremyiv/Documents/graphkit-1/graphkit/functional.py", line 209, in __call__
    net.compile()
  File "/home/jeremyiv/Documents/graphkit-1/graphkit/network.py", line 126, in compile
    raise Exception(f"Cyclic dependency in graph:\n{_format_cycle(cycle)}")
Exception: Cyclic dependency in graph:
op1 needs "a" from op4.
op4 needs "c" from op1.
```
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
